### PR TITLE
Fix center icon sizing

### DIFF
--- a/src/pages/Home.ts
+++ b/src/pages/Home.ts
@@ -14,6 +14,8 @@ export default Blits.Component("Home", {
     <Element :w="$w" :h="$h" color="#000000">
       <Element
         src="assets/icon.png"
+        :w="$iconSize"
+        :h="$iconSize"
         mount="{x: 0.5, y: 0.5}"
         :x="$w / 2"
         :y="$h / 2"
@@ -27,6 +29,11 @@ export default Blits.Component("Home", {
       w: window.innerWidth as number,
       /** Height of the canvas, updated on resize */
       h: window.innerHeight as number,
+      /**
+       * Calculated size of the icon. The value is based on the smaller
+       * dimension of the viewport to maintain a square aspect ratio.
+       */
+      iconSize: (Math.min(window.innerWidth, window.innerHeight) / 4) as number,
       /** Rotation of the icon in degrees */
       rotation: 0 as number,
     };
@@ -40,6 +47,8 @@ export default Blits.Component("Home", {
       const updateDimensions = () => {
         this.w = window.innerWidth;
         this.h = window.innerHeight;
+        // Adjust the icon size based on the new viewport dimensions
+        this.iconSize = Math.min(this.w, this.h) / 4;
         if (typeof document !== "undefined") {
           const canvas = document.querySelector(
             "canvas",

--- a/test/pages/Home.test.ts
+++ b/test/pages/Home.test.ts
@@ -37,6 +37,7 @@ const ready = homeConfig.hooks.ready as (
     startSpin: () => void;
     w: number;
     h: number;
+    iconSize: number;
   },
 ) => void;
 
@@ -67,11 +68,13 @@ describe("Home.hooks.ready", () => {
     };
 
     const spinSpy = vi.fn();
-    const context = { startSpin: spinSpy, w: 0, h: 0 };
+    const context = { startSpin: spinSpy, w: 0, h: 0, iconSize: 0 };
     ready.call(context);
     expect(spinSpy).toHaveBeenCalled();
     expect(context.w).toBe(100);
     expect(context.h).toBe(80);
+    // iconSize should be based on the smallest dimension divided by four
+    expect(context.iconSize).toBe(20);
     expect(addEventListener).toHaveBeenCalledWith(
       "resize",
       expect.any(Function),
@@ -83,6 +86,7 @@ describe("Home.hooks.ready", () => {
     resizeCb();
     expect(context.w).toBe(50);
     expect(context.h).toBe(60);
+    expect(context.iconSize).toBe(12.5);
 
     (globalThis as any).window = originalWindow;
   });


### PR DESCRIPTION
## Summary
- calculate icon size based on viewport to keep it square
- update resize logic and add tests for icon sizing

## Testing
- `pnpm format`
- `pnpm build`
- `pnpm test`
