### PR TITLE
Fix center icon sizing

### DIFF
--- a/src/pages/Home.ts
+++ b/src/pages/Home.ts
@@ -14,9 +14,11 @@ export default Blits.Component("Home", {
     <Element :w="$w" :h="$h" color="#000000">
       <Element
         src="assets/icon.png"
+        :w="$iconSize"
+        :h="$iconSize"
         mount="{x: 0.5, y: 0.5}"
-        :x="$w / 2"
-        :y="$h / 2"
+        :x="$centerX"
+        :y="$centerY"
         :rotation.transition="{value: $rotation, duration: 800, easing: 'cubic-bezier(0.34,1.56,0.64,1)'}"
       />
     </Element>
@@ -27,6 +29,15 @@ export default Blits.Component("Home", {
       w: window.innerWidth as number,
       /** Height of the canvas, updated on resize */
       h: window.innerHeight as number,
+      /** X coordinate of the icon center */
+      centerX: (window.innerWidth / 2) as number,
+      /** Y coordinate of the icon center */
+      centerY: (window.innerHeight / 2) as number,
+      /**
+       * Calculated size of the icon. The value is based on the smaller
+       * dimension of the viewport to maintain a square aspect ratio.
+       */
+      iconSize: (Math.min(window.innerWidth, window.innerHeight) / 4) as number,
       /** Rotation of the icon in degrees */
       rotation: 0 as number,
     };
@@ -37,9 +48,16 @@ export default Blits.Component("Home", {
        * Helper to synchronize the canvas and component size with the browser
        * window.
        */
-      const updateDimensions = () => {
+      const updateDimensions = (): void => {
         this.w = window.innerWidth;
         this.h = window.innerHeight;
+        // Maintain the center point based on the updated dimensions
+        this.centerX = this.w / 2;
+        this.centerY = this.h / 2;
+        // Adjust the icon size based on the new viewport dimensions
+        this.iconSize = Math.min(this.w, this.h) / 4;
+        // Inform the renderer about the new dimensions
+        this.$size({ w: this.w, h: this.h });
         if (typeof document !== "undefined") {
           const canvas = document.querySelector(
             "canvas",

--- a/test/pages/Home.test.ts
+++ b/test/pages/Home.test.ts
@@ -37,6 +37,10 @@ const ready = homeConfig.hooks.ready as (
     startSpin: () => void;
     w: number;
     h: number;
+    centerX: number;
+    centerY: number;
+    iconSize: number;
+    $size: (errDimensions: { w: number; h: number }) => void;
   },
 ) => void;
 
@@ -67,11 +71,25 @@ describe("Home.hooks.ready", () => {
     };
 
     const spinSpy = vi.fn();
-    const context = { startSpin: spinSpy, w: 0, h: 0 };
+    const sizeSpy = vi.fn();
+    const context = {
+      startSpin: spinSpy,
+      w: 0,
+      h: 0,
+      centerX: 0,
+      centerY: 0,
+      iconSize: 0,
+      $size: sizeSpy,
+    };
     ready.call(context);
     expect(spinSpy).toHaveBeenCalled();
     expect(context.w).toBe(100);
     expect(context.h).toBe(80);
+    expect(context.centerX).toBe(50);
+    expect(context.centerY).toBe(40);
+    // iconSize should be based on the smallest dimension divided by four
+    expect(context.iconSize).toBe(20);
+    expect(sizeSpy).toHaveBeenCalledWith({ w: 100, h: 80 });
     expect(addEventListener).toHaveBeenCalledWith(
       "resize",
       expect.any(Function),
@@ -83,6 +101,10 @@ describe("Home.hooks.ready", () => {
     resizeCb();
     expect(context.w).toBe(50);
     expect(context.h).toBe(60);
+    expect(context.centerX).toBe(25);
+    expect(context.centerY).toBe(30);
+    expect(context.iconSize).toBe(12.5);
+    expect(sizeSpy).toHaveBeenLastCalledWith({ w: 50, h: 60 });
 
     (globalThis as any).window = originalWindow;
   });


### PR DESCRIPTION
## Summary
- calculate icon size based on viewport to keep it square
- update resize logic and add tests for icon sizing
- ensure icon stays centered and notify renderer on resize

## Testing
- `pnpm format`
- `pnpm build`
- `pnpm test`
