### PR TITLE
Fix center icon sizing

### DIFF
--- a/src/pages/Home.ts
+++ b/src/pages/Home.ts
@@ -14,6 +14,8 @@ export default Blits.Component("Home", {
     <Element :w="$w" :h="$h" color="#000000">
       <Element
         src="assets/icon.png"
+        :w="$iconSize"
+        :h="$iconSize"
         mount="{x: 0.5, y: 0.5}"
         :x="$w / 2"
         :y="$h / 2"
@@ -27,6 +29,11 @@ export default Blits.Component("Home", {
       w: window.innerWidth as number,
       /** Height of the canvas, updated on resize */
       h: window.innerHeight as number,
+      /**
+       * Calculated size of the icon. The value is based on the smaller
+       * dimension of the viewport to maintain a square aspect ratio.
+       */
+      iconSize: (Math.min(window.innerWidth, window.innerHeight) / 4) as number,
       /** Rotation of the icon in degrees */
       rotation: 0 as number,
     };
@@ -37,9 +44,11 @@ export default Blits.Component("Home", {
        * Helper to synchronize the canvas and component size with the browser
        * window.
        */
-      const updateDimensions = () => {
+      const updateDimensions = (): void => {
         this.w = window.innerWidth;
         this.h = window.innerHeight;
+        // Adjust the icon size based on the new viewport dimensions
+        this.iconSize = Math.min(this.w, this.h) / 4;
         if (typeof document !== "undefined") {
           const canvas = document.querySelector(
             "canvas",
@@ -51,6 +60,8 @@ export default Blits.Component("Home", {
             canvas.style.height = `${this.h}px`;
           }
         }
+        // Notify the renderer so the component layout stays in sync
+        this.$size({ w: this.w, h: this.h });
       };
 
       // Ensure correct initial dimensions and react to future resizes

--- a/test/pages/Home.test.ts
+++ b/test/pages/Home.test.ts
@@ -37,6 +37,8 @@ const ready = homeConfig.hooks.ready as (
     startSpin: () => void;
     w: number;
     h: number;
+    iconSize: number;
+    $size: (errDimensions: { w: number; h: number }) => void;
   },
 ) => void;
 
@@ -67,11 +69,21 @@ describe("Home.hooks.ready", () => {
     };
 
     const spinSpy = vi.fn();
-    const context = { startSpin: spinSpy, w: 0, h: 0 };
+    const sizeSpy = vi.fn();
+    const context = {
+      startSpin: spinSpy,
+      w: 0,
+      h: 0,
+      iconSize: 0,
+      $size: sizeSpy,
+    };
     ready.call(context);
     expect(spinSpy).toHaveBeenCalled();
     expect(context.w).toBe(100);
     expect(context.h).toBe(80);
+    // iconSize should be based on the smallest dimension divided by four
+    expect(context.iconSize).toBe(20);
+    expect(sizeSpy).toHaveBeenCalledWith({ w: 100, h: 80 });
     expect(addEventListener).toHaveBeenCalledWith(
       "resize",
       expect.any(Function),
@@ -83,6 +95,8 @@ describe("Home.hooks.ready", () => {
     resizeCb();
     expect(context.w).toBe(50);
     expect(context.h).toBe(60);
+    expect(context.iconSize).toBe(12.5);
+    expect(sizeSpy).toHaveBeenCalledWith({ w: 50, h: 60 });
 
     (globalThis as any).window = originalWindow;
   });


### PR DESCRIPTION
## Summary
- calculate icon size based on viewport to keep it square
- notify renderer of size changes so icon stays centered
- update tests for size updates on resize

## Testing
- `pnpm format`
- `pnpm build`
- `pnpm test`
