### PR TITLE
Handle resize with debounce

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,34 @@ import Blits from "@lightningjs/blits";
 
 import App from "./App";
 
-Blits.Launch(App, "app", {
-  w: window.innerWidth,
-  h: window.innerHeight,
-});
+// Debounce wait period for resize/orientation events in milliseconds
+const RESIZE_DEBOUNCE_MS = 100;
+
+// Reference to the timeout used for debouncing resize and orientation events
+let resizeTimeout: number | undefined;
+
+function launchApp(): void {
+  // Remove any previous content so the stage can be recreated cleanly
+  const container = document.getElementById("app");
+  if (container) {
+    container.innerHTML = "";
+  }
+
+  // Launch a new Lightning Blits application sized to the current viewport
+  Blits.Launch(App, "app", {
+    w: window.innerWidth,
+    h: window.innerHeight,
+  });
+}
+
+function debouncedLaunch(): void {
+  // Queue a relaunch after no resize events have fired for a short period
+  window.clearTimeout(resizeTimeout);
+  resizeTimeout = window.setTimeout(launchApp, RESIZE_DEBOUNCE_MS);
+}
+
+// React to browser resize and orientation changes
+window.addEventListener("resize", debouncedLaunch);
+window.addEventListener("orientationchange", debouncedLaunch);
+
+launchApp();


### PR DESCRIPTION
## Summary
- debounce the resize and orientation event handler to avoid excessive relaunches
- move debounce timeout to a constant and expand comments

## Testing
- `pnpm exec eslint src/index.ts`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6842429b67908326a7e139b0d844ef90