### PR TITLE
Remove redundant ts eslint dependency

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,7 +7,8 @@
  */
 
 import js from "@eslint/js";
-import * as tseslint from "typescript-eslint";
+import parser from "@typescript-eslint/parser";
+import plugin from "@typescript-eslint/eslint-plugin";
 import simpleImportSort from "eslint-plugin-simple-import-sort";
 import prettierConfig from "eslint-config-prettier";
 import prettierPlugin from "eslint-plugin-prettier";
@@ -21,7 +22,7 @@ export default [
   {
     files: ["**/*.{ts,tsx}"],
     languageOptions: {
-      parser: tseslint.parser,
+      parser,
       parserOptions: {
         ecmaVersion: "latest",
         sourceType: "module",
@@ -34,12 +35,12 @@ export default [
       },
     },
     plugins: {
-      "@typescript-eslint": tseslint.plugin,
+      "@typescript-eslint": plugin,
       "simple-import-sort": simpleImportSort,
       prettier: prettierPlugin,
     },
     rules: {
-      ...tseslint.configs.recommended.rules,
+      ...plugin.configs.recommended.rules,
       "brace-style": ["error", "1tbs", { allowSingleLine: false }],
       curly: ["error", "all"],
       "simple-import-sort/imports": "error",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     "prettier": "^3.5.3",
     "prettier-plugin-pkg": "^0.19.1",
     "typescript": "^5.8.3",
-    "typescript-eslint": "^8.32.1",
     "vite": "^6.3.5",
     "vitest": "^3.1.4"
   },

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -38,6 +38,8 @@ interface FakeDocument {
   getElementById(errId: string): FakeElement;
 }
 
+// Describe the subset of the global object that our tests modify. This avoids
+// casting `globalThis` to `any` when assigning the fake window and document.
 interface TestGlobal {
   window?: Window & {
     innerWidth: number;

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -38,6 +38,15 @@ interface FakeDocument {
   getElementById(errId: string): FakeElement;
 }
 
+interface TestGlobal {
+  window?: Window & {
+    innerWidth: number;
+    innerHeight: number;
+    document: Document & FakeDocument;
+  };
+  document?: Document & FakeDocument;
+}
+
 beforeEach(() => {
   // Use fake timers so resize debouncing can be tested deterministically
   vi.useFakeTimers();
@@ -73,8 +82,9 @@ beforeEach(() => {
   fakeWindow.clearTimeout = globalThis.clearTimeout.bind(globalThis);
 
   // Expose the fake window and document on the global object so index.ts can access them
-  (globalThis as any).window = fakeWindow;
-  (globalThis as any).document = fakeDocument;
+  const globalObject: TestGlobal = globalThis as unknown as TestGlobal;
+  globalObject.window = fakeWindow;
+  globalObject.document = fakeDocument as unknown as Document & FakeDocument;
 
   launchSpy = Blits.Launch as ReturnType<typeof vi.fn>;
   launchSpy.mockClear();
@@ -86,8 +96,9 @@ afterEach(() => {
   vi.resetModules();
 
   // Clean up the global objects to avoid leaking state between tests
-  delete (globalThis as any).window;
-  delete (globalThis as any).document;
+  const globalObject: TestGlobal = globalThis as unknown as TestGlobal;
+  delete globalObject.window;
+  delete globalObject.document;
 });
 
 describe("index window events", () => {


### PR DESCRIPTION
## Summary
- clean up TypeScript ESLint deps
- adjust ESLint config to import explicit parser and plugin
- update tests to avoid `any` cast warnings

## Testing
- `pnpm lint`
- `pnpm build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68425d04fd3c832688d8176dfaec360f