### PR TITLE
Add resize handler and global state

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,7 +44,10 @@
     />
 
     <!-- Viewporting -->
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, viewport-fit=cover"
+    />
 
     <!-- Set the theme color for mobile browsers -->
     <meta name="theme-color" content="#000000" />
@@ -66,6 +69,13 @@
       * {
         padding: 0;
         margin: 0;
+      }
+      html,
+      body,
+      #app {
+        width: 100%;
+        height: 100%;
+        overflow: hidden;
       }
     </style>
   </head>

--- a/src/GlobalState.ts
+++ b/src/GlobalState.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2025 Garrett Brown
+ * This file is part of meditation.surf - https://github.com/eigendude/meditation.surf
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ * See the file LICENSE.txt for more information.
+ */
+
+/**
+ * Application-wide state preserved across Lightning app launches.
+ */
+export interface GlobalState {
+  /** Width of the application icon in pixels */
+  iconWidth: number;
+  /** Height of the application icon in pixels */
+  iconHeight: number;
+}
+
+/**
+ * Singleton instance holding global state.
+ */
+export const globalState: GlobalState = {
+  iconWidth: 0,
+  iconHeight: 0,
+};
+
+/**
+ * Load icon dimensions from the application icon and store them in globalState.
+ */
+export function loadIconDimensions(): void {
+  const icon: HTMLImageElement = new window.Image();
+  icon.onload = (): void => {
+    globalState.iconWidth = icon.width;
+    globalState.iconHeight = icon.height;
+  };
+  icon.src = "assets/icon.png";
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,9 +6,15 @@
  * See the file LICENSE.txt for more information.
  */
 
+import { loadIconDimensions } from "./GlobalState";
 import { launchLightningApp } from "./LightningApp";
 
 /**
- * Application entry point. Launches the LightningJS view.
+ * Application entry point. Loads global state and launches the LightningJS
+ * view.
  */
+loadIconDimensions();
 launchLightningApp();
+window.addEventListener("resize", (): void => {
+  launchLightningApp();
+});


### PR DESCRIPTION
## Summary
- expand viewport meta to `viewport-fit=cover`
- keep container elements full-screen with CSS
- create a `GlobalState` module for app-wide state
- load icon dimensions once and preserve them across LightningJS launches
- relaunch the app on window resize

## Testing
- `pnpm format`
- `pnpm lint`
- `pnpm build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68427aab60008326a292b5e7cd47b0f9