### PR TITLE
Refactor icon into reusable component

### DIFF
--- a/src/LightningApp.ts
+++ b/src/LightningApp.ts
@@ -11,16 +11,72 @@ import Blits from "@lightningjs/blits";
 // Type alias for the factory returned by Blits.Application
 type LightningAppFactory = ReturnType<typeof Blits.Application>;
 
-// Minimal LightningJS app
-const LightningApp: LightningAppFactory = Blits.Application({});
+// Minimal LightningJS app displaying a full-screen icon
+const LightningApp: LightningAppFactory = Blits.Application({
+  // Track viewport dimensions for the root stage
+  state() {
+    return {
+      stageW: window.innerWidth as number, // viewport width
+      stageH: window.innerHeight as number, // viewport height
+    };
+  },
+
+  computed: {
+    /**
+     * Size of the square icon that covers the viewport.
+     * The largest stage dimension is used so the icon
+     * always fills the screen while keeping its aspect ratio.
+     */
+    iconSize(): number {
+      return Math.max(this.stageW, this.stageH);
+    },
+  },
+
+  hooks: {
+    /**
+     * Setup the window resize handler so the app continues to
+     * cover the viewport when the browser size changes.
+     */
+    init(): void {
+      const self: any = this;
+      const listener: () => void = (): void => {
+        self.stageW = window.innerWidth;
+        self.stageH = window.innerHeight;
+      };
+      self.resizeListener = listener;
+      window.addEventListener("resize", listener);
+    },
+
+    /**
+     * Clean up the resize listener when the component is destroyed.
+     */
+    destroy(): void {
+      const self: any = this;
+      if (self.resizeListener) {
+        window.removeEventListener("resize", self.resizeListener as () => void);
+      }
+    },
+  },
+
+  // Render the icon centered on a black canvas
+  template: `<Element :w="$stageW" :h="$stageH">
+    <Element
+      src="assets/icon.png"
+      :w="$iconSize"
+      :h="$iconSize"
+      :x="$stageW / 2"
+      :y="$stageH / 2"
+      :mount="0.5"
+    />
+  </Element>`,
+});
 
 /**
  * Launch the LightningJS application sized to the current viewport
  */
-export function launchLightningApp(): void {
+export function launchLightningApp(width: number, height: number): void {
   Blits.Launch(LightningApp, "app", {
-    w: window.innerWidth,
-    h: window.innerHeight,
-    canvasColor: "#000000",
+    w: width,
+    h: height,
   });
 }

--- a/src/LightningApp.ts
+++ b/src/LightningApp.ts
@@ -8,6 +8,8 @@
 
 import Blits from "@lightningjs/blits";
 
+import Icon from "./components/Icon";
+
 // Type alias for the factory returned by Blits.Application
 type LightningAppFactory = ReturnType<typeof Blits.Application>;
 
@@ -21,16 +23,12 @@ const LightningApp: LightningAppFactory = Blits.Application({
     };
   },
 
-  computed: {
-    /**
-     * Size of the square icon that covers the viewport.
-     * The largest stage dimension is used so the icon
-     * always fills the screen while keeping its aspect ratio.
-     */
-    iconSize(): number {
-      return Math.max(this.stageW, this.stageH);
-    },
+  // Register child components available in the template
+  components: {
+    Icon,
   },
+
+  // No computed properties for the stage itself
 
   hooks: {
     /**
@@ -58,16 +56,9 @@ const LightningApp: LightningAppFactory = Blits.Application({
     },
   },
 
-  // Render the icon centered on a black canvas
+  // Render the icon component centered on a black canvas
   template: `<Element :w="$stageW" :h="$stageH">
-    <Element
-      src="assets/icon.png"
-      :w="$iconSize"
-      :h="$iconSize"
-      :x="$stageW / 2"
-      :y="$stageH / 2"
-      :mount="0.5"
-    />
+    <Icon :stageW="$stageW" :stageH="$stageH" />
   </Element>`,
 });
 

--- a/src/components/Icon.ts
+++ b/src/components/Icon.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2025 Garrett Brown
+ * This file is part of meditation.surf - https://github.com/eigendude/meditation.surf
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ * See the file LICENSE.txt for more information.
+ */
+
+import Blits from "@lightningjs/blits";
+
+// Type alias for the factory returned by Blits.Component
+type IconFactory = ReturnType<typeof Blits.Component>;
+
+/**
+ * A reusable component that displays the app icon centered on the stage.
+ * The icon always covers the entire viewport while maintaining its aspect ratio.
+ */
+const Icon: IconFactory = Blits.Component("Icon", {
+  // Stage dimensions passed from the parent component
+  props: ["stageW", "stageH"],
+
+  computed: {
+    /**
+     * Size of the square icon in pixels.
+     * The largest stage dimension is used so the icon fills the screen
+     * while keeping its aspect ratio.
+     */
+    iconSize(): number {
+      // @ts-ignore `this` contains the reactive props provided at runtime
+      return Math.max(this.stageW as number, this.stageH as number);
+    },
+  },
+
+  // Render the icon centered at half mount
+  template: `<Element
+      src="assets/icon.png"
+      :w="$iconSize"
+      :h="$iconSize"
+      :x="$stageW / 2"
+      :y="$stageH / 2"
+      :mount="0.5"
+    />`,
+});
+
+export default Icon;

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,8 +8,46 @@
 
 import { launchLightningApp } from "./LightningApp";
 
+/** Milliseconds to wait before applying the final size after a resize */
+const COOL_DOWN_MS: number = 100;
+
+let coolDownTimer: number | undefined;
+let lastWidth: number = window.innerWidth;
+let lastHeight: number = window.innerHeight;
+
+/** Launch the app, replacing any existing canvas */
+function startApp(width: number, height: number): void {
+  const mount: HTMLElement = document.getElementById("app") as HTMLElement;
+  const oldCanvas: HTMLCanvasElement | null = mount.querySelector("canvas");
+
+  // Launch the new LightningJS canvas before removing the old one to minimize
+  // the time the screen goes blank during a resize
+  launchLightningApp(width, height);
+
+  if (oldCanvas !== null) {
+    oldCanvas.remove();
+  }
+}
+
+window.addEventListener("resize", (): void => {
+  lastWidth = window.innerWidth;
+  lastHeight = window.innerHeight;
+
+  // Apply the new resolution immediately if we're not in the cooldown period
+  if (coolDownTimer === undefined) {
+    startApp(lastWidth, lastHeight);
+  }
+
+  // Restart the cooldown timer to apply the last resolution after the cooldown
+  window.clearTimeout(coolDownTimer);
+  coolDownTimer = window.setTimeout((): void => {
+    startApp(lastWidth, lastHeight);
+    coolDownTimer = undefined;
+  }, COOL_DOWN_MS);
+});
+
 /**
  * Application entry point. Loads global state and launches the LightningJS
  * view.
  */
-launchLightningApp();
+startApp(window.innerWidth, window.innerHeight);


### PR DESCRIPTION
## Summary
- factor icon display into new Icon component
- use Icon component inside LightningApp

## Testing
- `pnpm lint`
- `CI=true pnpm build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68448c985d648326855158a3693a2c18