### PR TITLE
Refactor LightningApp exports

### DIFF
--- a/src/LightningApp.ts
+++ b/src/LightningApp.ts
@@ -62,12 +62,4 @@ const LightningApp: LightningAppFactory = Blits.Application({
   </Element>`,
 });
 
-/**
- * Launch the LightningJS application sized to the current viewport
- */
-export function launchLightningApp(width: number, height: number): void {
-  Blits.Launch(LightningApp, "app", {
-    w: width,
-    h: height,
-  });
-}
+export default LightningApp;

--- a/src/LightningApp.ts
+++ b/src/LightningApp.ts
@@ -8,19 +8,66 @@
 
 import Blits from "@lightningjs/blits";
 
+import Icon from "./components/Icon";
+
 // Type alias for the factory returned by Blits.Application
 type LightningAppFactory = ReturnType<typeof Blits.Application>;
 
-// Minimal LightningJS app
-const LightningApp: LightningAppFactory = Blits.Application({});
+// Minimal LightningJS app displaying a full-screen icon
+const LightningApp: LightningAppFactory = Blits.Application({
+  // Track viewport dimensions for the root stage
+  state() {
+    return {
+      stageW: window.innerWidth as number, // viewport width
+      stageH: window.innerHeight as number, // viewport height
+    };
+  },
+
+  // Register child components available in the template
+  components: {
+    Icon,
+  },
+
+  // No computed properties for the stage itself
+
+  hooks: {
+    /**
+     * Setup the window resize handler so the app continues to
+     * cover the viewport when the browser size changes.
+     */
+    init(): void {
+      const self: any = this;
+      const listener: () => void = (): void => {
+        self.stageW = window.innerWidth;
+        self.stageH = window.innerHeight;
+      };
+      self.resizeListener = listener;
+      window.addEventListener("resize", listener);
+    },
+
+    /**
+     * Clean up the resize listener when the component is destroyed.
+     */
+    destroy(): void {
+      const self: any = this;
+      if (self.resizeListener) {
+        window.removeEventListener("resize", self.resizeListener as () => void);
+      }
+    },
+  },
+
+  // Render the icon component centered on a black canvas
+  template: `<Element :w="$stageW" :h="$stageH">
+    <Icon :stageW="$stageW" :stageH="$stageH" />
+  </Element>`,
+});
 
 /**
  * Launch the LightningJS application sized to the current viewport
  */
-export function launchLightningApp(): void {
+export function launchLightningApp(width: number, height: number): void {
   Blits.Launch(LightningApp, "app", {
-    w: window.innerWidth,
-    h: window.innerHeight,
-    canvasColor: "#000000",
+    w: width,
+    h: height,
   });
 }

--- a/src/components/Icon.ts
+++ b/src/components/Icon.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2025 Garrett Brown
+ * This file is part of meditation.surf - https://github.com/eigendude/meditation.surf
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ * See the file LICENSE.txt for more information.
+ */
+
+import Blits from "@lightningjs/blits";
+
+// Type alias for the factory returned by Blits.Component
+type IconFactory = ReturnType<typeof Blits.Component>;
+
+/**
+ * A reusable component that displays the app icon centered on the stage.
+ * The icon always covers the entire viewport while maintaining its aspect ratio.
+ */
+const Icon: IconFactory = Blits.Component("Icon", {
+  // Stage dimensions passed from the parent component
+  props: ["stageW", "stageH"],
+
+  computed: {
+    /**
+     * Size of the square icon in pixels.
+     * The largest stage dimension is used so the icon fills the screen
+     * while keeping its aspect ratio.
+     */
+    iconSize(): number {
+      // @ts-ignore `this` contains the reactive props provided at runtime
+      return Math.max(this.stageW as number, this.stageH as number);
+    },
+  },
+
+  // Render the icon centered at half mount
+  template: `<Element
+      src="assets/icon.png"
+      :w="$iconSize"
+      :h="$iconSize"
+      :x="$stageW / 2"
+      :y="$stageH / 2"
+      :mount="0.5"
+    />`,
+});
+
+export default Icon;

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,9 +7,34 @@
  */
 
 import { launchLightningApp } from "./LightningApp";
+import { debounce } from "./utils/debounce";
+
+/** Milliseconds to wait before applying the final size after a resize */
+const COOL_DOWN_MS: number = 100;
+
+/** Launch the app, replacing any existing canvas */
+function startApp(width: number, height: number): void {
+  const mount: HTMLElement = document.getElementById("app") as HTMLElement;
+  const oldCanvas: HTMLCanvasElement | null = mount.querySelector("canvas");
+
+  // Launch the new LightningJS canvas before removing the old one to minimize
+  // the time the screen goes blank during a resize
+  launchLightningApp(width, height);
+
+  if (oldCanvas !== null) {
+    oldCanvas.remove();
+  }
+}
+
+const debouncedStartApp: (...errArgs: Parameters<typeof startApp>) => void =
+  debounce(startApp, COOL_DOWN_MS);
+
+window.addEventListener("resize", (): void => {
+  debouncedStartApp(window.innerWidth, window.innerHeight);
+});
 
 /**
  * Application entry point. Loads global state and launches the LightningJS
  * view.
  */
-launchLightningApp();
+startApp(window.innerWidth, window.innerHeight);

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,8 +6,20 @@
  * See the file LICENSE.txt for more information.
  */
 
-import { launchLightningApp } from "./LightningApp";
+import Blits from "@lightningjs/blits";
+
+import LightningApp from "./LightningApp";
 import { debounce } from "./utils/debounce";
+
+/**
+ * Launch the LightningJS application sized to the current viewport.
+ */
+function launchLightningApp(width: number, height: number): void {
+  Blits.Launch(LightningApp, "app", {
+    w: width,
+    h: height,
+  });
+}
 
 /** Milliseconds to wait before applying the final size after a resize */
 const COOL_DOWN_MS: number = 100;

--- a/src/utils/debounce.ts
+++ b/src/utils/debounce.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2025 Garrett Brown
+ * This file is part of meditation.surf - https://github.com/eigendude/meditation.surf
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ * See the file LICENSE.txt for more information.
+ */
+
+/**
+ * Create a function that executes the callback immediately and again after the
+ * specified delay if it continues to be invoked. The trailing execution uses
+ * the arguments from the last invocation.
+ *
+ * @param callback - Function to debounce
+ * @param waitMs - Milliseconds to wait before the trailing execution
+ * @returns A debounced version of the callback
+ */
+export function debounce<Args extends unknown[]>(
+  callback: (...errArgs: Args) => void,
+  waitMs: number,
+): (...errArgs: Args) => void {
+  let timer: number | undefined;
+
+  return (...errArgs: Args): void => {
+    if (timer === undefined) {
+      callback(...errArgs);
+    }
+
+    window.clearTimeout(timer);
+    timer = window.setTimeout((): void => {
+      callback(...errArgs);
+      timer = undefined;
+    }, waitMs);
+  };
+}


### PR DESCRIPTION
## Summary
- remove `launchLightningApp` from `LightningApp.ts`
- export `LightningApp` as default
- move launcher function to `index.ts`

## Testing
- `pnpm lint`
- `pnpm build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_684490f41de48326ae68801d6f8e08cd