### PR TITLE
Implement quad icon display

### DIFF
--- a/src/LightningApp.ts
+++ b/src/LightningApp.ts
@@ -8,19 +8,58 @@
 
 import Blits from "@lightningjs/blits";
 
+import Icon from "./components/Icon";
+
 // Type alias for the factory returned by Blits.Application
 type LightningAppFactory = ReturnType<typeof Blits.Application>;
 
-// Minimal LightningJS app
-const LightningApp: LightningAppFactory = Blits.Application({});
+// Minimal LightningJS app displaying a full-screen icon
+const LightningApp: LightningAppFactory = Blits.Application({
+  // Track viewport dimensions for the root stage
+  state() {
+    return {
+      stageW: window.innerWidth as number, // viewport width
+      stageH: window.innerHeight as number, // viewport height
+    };
+  },
 
-/**
- * Launch the LightningJS application sized to the current viewport
- */
-export function launchLightningApp(): void {
-  Blits.Launch(LightningApp, "app", {
-    w: window.innerWidth,
-    h: window.innerHeight,
-    canvasColor: "#000000",
-  });
-}
+  // Register child components available in the template
+  components: {
+    Icon,
+  },
+
+  // No computed properties for the stage itself
+
+  hooks: {
+    /**
+     * Setup the window resize handler so the app continues to
+     * cover the viewport when the browser size changes.
+     */
+    init(): void {
+      const self: any = this;
+      const listener: () => void = (): void => {
+        self.stageW = window.innerWidth;
+        self.stageH = window.innerHeight;
+      };
+      self.resizeListener = listener;
+      window.addEventListener("resize", listener);
+    },
+
+    /**
+     * Clean up the resize listener when the component is destroyed.
+     */
+    destroy(): void {
+      const self: any = this;
+      if (self.resizeListener) {
+        window.removeEventListener("resize", self.resizeListener as () => void);
+      }
+    },
+  },
+
+  // Render the icon component centered on a black canvas
+  template: `<Element :w="$stageW" :h="$stageH">
+    <Icon :stageW="$stageW" :stageH="$stageH" />
+  </Element>`,
+});
+
+export default LightningApp;

--- a/src/LightningApp.ts
+++ b/src/LightningApp.ts
@@ -8,7 +8,7 @@
 
 import Blits from "@lightningjs/blits";
 
-import Icon from "./components/Icon";
+import QuadIcon from "./components/QuadIcon";
 
 // Type alias for the factory returned by Blits.Application
 type LightningAppFactory = ReturnType<typeof Blits.Application>;
@@ -25,7 +25,7 @@ const LightningApp: LightningAppFactory = Blits.Application({
 
   // Register child components available in the template
   components: {
-    Icon,
+    QuadIcon,
   },
 
   // No computed properties for the stage itself
@@ -58,7 +58,7 @@ const LightningApp: LightningAppFactory = Blits.Application({
 
   // Render the icon component centered on a black canvas
   template: `<Element :w="$stageW" :h="$stageH">
-    <Icon :stageW="$stageW" :stageH="$stageH" />
+    <QuadIcon :stageW="$stageW" :stageH="$stageH" />
   </Element>`,
 });
 

--- a/src/components/Icon.ts
+++ b/src/components/Icon.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2025 Garrett Brown
+ * This file is part of meditation.surf - https://github.com/eigendude/meditation.surf
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ * See the file LICENSE.txt for more information.
+ */
+
+import Blits from "@lightningjs/blits";
+
+// Type alias for the factory returned by Blits.Component
+type IconFactory = ReturnType<typeof Blits.Component>;
+
+/**
+ * A reusable component that displays the app icon centered on the stage.
+ * The icon always covers the entire viewport while maintaining its aspect ratio.
+ */
+const Icon: IconFactory = Blits.Component("Icon", {
+  // Stage dimensions passed from the parent component
+  props: ["stageW", "stageH"],
+
+  computed: {
+    /**
+     * Size of the square icon in pixels.
+     * The largest stage dimension is used so the icon fills the screen
+     * while keeping its aspect ratio.
+     */
+    iconSize(): number {
+      // @ts-ignore `this` contains the reactive props provided at runtime
+      return Math.max(this.stageW as number, this.stageH as number);
+    },
+  },
+
+  // Render the icon centered at half mount
+  template: `<Element
+      src="assets/icon.png"
+      :w="$iconSize"
+      :h="$iconSize"
+      :x="$stageW / 2"
+      :y="$stageH / 2"
+      :mount="0.5"
+    />`,
+});
+
+export default Icon;

--- a/src/components/QuadIcon.ts
+++ b/src/components/QuadIcon.ts
@@ -20,49 +20,74 @@ const QuadIcon: QuadIconFactory = Blits.Component("QuadIcon", {
   props: ["stageW", "stageH"],
 
   computed: {
-    /** Width of each quadrant in pixels. */
-    cellW(): number {
+    /** Width of half of the viewport. */
+    halfW(): number {
       // @ts-ignore `this` contains the reactive props provided at runtime
       return (this.stageW as number) / 2;
     },
 
-    /** Height of each quadrant in pixels. */
-    cellH(): number {
+    /** Height of half of the viewport. */
+    halfH(): number {
       // @ts-ignore `this` contains the reactive props provided at runtime
       return (this.stageH as number) / 2;
     },
+
+    /**
+     * Size of the square icon in pixels. The longest stage
+     * dimension is used to keep the icon centered when cropping.
+     */
+    iconSize(): number {
+      // @ts-ignore `this` contains the reactive props provided at runtime
+      return Math.max(this.stageW as number, this.stageH as number);
+    },
   },
 
-  // Render four cropped icons positioned in a 2x2 grid
+  // Render a single icon sliced into quadrants using clipping
   template: `<Element :w="$stageW" :h="$stageH">
-      <Element
-        src="assets/icon.png"
-        :w="$cellW"
-        :h="$cellH"
-        fit="{type: 'cover', position: {x: 0, y: 0}}"
-      />
-      <Element
-        src="assets/icon.png"
-        :x="$cellW"
-        :w="$cellW"
-        :h="$cellH"
-        fit="{type: 'cover', position: {x: 1, y: 0}}"
-      />
-      <Element
-        src="assets/icon.png"
-        :y="$cellH"
-        :w="$cellW"
-        :h="$cellH"
-        fit="{type: 'cover', position: {x: 0, y: 1}}"
-      />
-      <Element
-        src="assets/icon.png"
-        :x="$cellW"
-        :y="$cellH"
-        :w="$cellW"
-        :h="$cellH"
-        fit="{type: 'cover', position: {x: 1, y: 1}}"
-      />
+      <!-- Top-left corner -->
+      <Element :w="$halfW" :h="$halfH" clipping="true">
+        <Element
+          src="assets/icon.png"
+          :w="$iconSize"
+          :h="$iconSize"
+          :x="$stageW / 2"
+          :y="$stageH / 2"
+          mount="0.5"
+        />
+      </Element>
+      <!-- Top-right corner -->
+      <Element :x="$halfW" :w="$halfW" :h="$halfH" clipping="true">
+        <Element
+          src="assets/icon.png"
+          :w="$iconSize"
+          :h="$iconSize"
+          :x="0"
+          :y="$stageH / 2"
+          mount="0.5"
+        />
+      </Element>
+      <!-- Bottom-left corner -->
+      <Element :y="$halfH" :w="$halfW" :h="$halfH" clipping="true">
+        <Element
+          src="assets/icon.png"
+          :w="$iconSize"
+          :h="$iconSize"
+          :x="$stageW / 2"
+          :y="0"
+          mount="0.5"
+        />
+      </Element>
+      <!-- Bottom-right corner -->
+      <Element :x="$halfW" :y="$halfH" :w="$halfW" :h="$halfH" clipping="true">
+        <Element
+          src="assets/icon.png"
+          :w="$iconSize"
+          :h="$iconSize"
+          :x="0"
+          :y="0"
+          mount="0.5"
+        />
+      </Element>
     </Element>`,
 });
 

--- a/src/components/QuadIcon.ts
+++ b/src/components/QuadIcon.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2025 Garrett Brown
+ * This file is part of meditation.surf - https://github.com/eigendude/meditation.surf
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ * See the file LICENSE.txt for more information.
+ */
+
+import Blits from "@lightningjs/blits";
+
+// Type alias for the factory returned by Blits.Component
+type QuadIconFactory = ReturnType<typeof Blits.Component>;
+
+/**
+ * Display the app icon four times, cropped into quadrants.
+ * Each icon occupies a quarter of the viewport and resizes with the window.
+ */
+const QuadIcon: QuadIconFactory = Blits.Component("QuadIcon", {
+  // Stage dimensions passed from the parent component
+  props: ["stageW", "stageH"],
+
+  computed: {
+    /** Width of each quadrant in pixels. */
+    cellW(): number {
+      // @ts-ignore `this` contains the reactive props provided at runtime
+      return (this.stageW as number) / 2;
+    },
+
+    /** Height of each quadrant in pixels. */
+    cellH(): number {
+      // @ts-ignore `this` contains the reactive props provided at runtime
+      return (this.stageH as number) / 2;
+    },
+  },
+
+  // Render four cropped icons positioned in a 2x2 grid
+  template: `<Element :w="$stageW" :h="$stageH">
+      <Element
+        src="assets/icon.png"
+        :w="$cellW"
+        :h="$cellH"
+        fit="{type: 'cover', position: {x: 0, y: 0}}"
+      />
+      <Element
+        src="assets/icon.png"
+        :x="$cellW"
+        :w="$cellW"
+        :h="$cellH"
+        fit="{type: 'cover', position: {x: 1, y: 0}}"
+      />
+      <Element
+        src="assets/icon.png"
+        :y="$cellH"
+        :w="$cellW"
+        :h="$cellH"
+        fit="{type: 'cover', position: {x: 0, y: 1}}"
+      />
+      <Element
+        src="assets/icon.png"
+        :x="$cellW"
+        :y="$cellH"
+        :w="$cellW"
+        :h="$cellH"
+        fit="{type: 'cover', position: {x: 1, y: 1}}"
+      />
+    </Element>`,
+});
+
+export default QuadIcon;

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,47 +6,7 @@
  * See the file LICENSE.txt for more information.
  */
 
-import Blits from "@lightningjs/blits";
+import { launchApp } from "./launchApp";
 
-import LightningApp from "./LightningApp";
-import { debounce } from "./utils/debounce";
-
-/**
- * Launch the LightningJS application sized to the current viewport.
- */
-function launchLightningApp(width: number, height: number): void {
-  Blits.Launch(LightningApp, "app", {
-    w: width,
-    h: height,
-  });
-}
-
-/** Milliseconds to wait before applying the final size after a resize */
-const COOL_DOWN_MS: number = 100;
-
-/** Launch the app, replacing any existing canvas */
-function startApp(width: number, height: number): void {
-  const mount: HTMLElement = document.getElementById("app") as HTMLElement;
-  const oldCanvas: HTMLCanvasElement | null = mount.querySelector("canvas");
-
-  // Launch the new LightningJS canvas before removing the old one to minimize
-  // the time the screen goes blank during a resize
-  launchLightningApp(width, height);
-
-  if (oldCanvas !== null) {
-    oldCanvas.remove();
-  }
-}
-
-const debouncedStartApp: (...errArgs: Parameters<typeof startApp>) => void =
-  debounce(startApp, COOL_DOWN_MS);
-
-window.addEventListener("resize", (): void => {
-  debouncedStartApp(window.innerWidth, window.innerHeight);
-});
-
-/**
- * Application entry point. Loads global state and launches the LightningJS
- * view.
- */
-startApp(window.innerWidth, window.innerHeight);
+// Application entry point
+launchApp();

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,10 +6,47 @@
  * See the file LICENSE.txt for more information.
  */
 
-import { launchLightningApp } from "./LightningApp";
+import Blits from "@lightningjs/blits";
+
+import LightningApp from "./LightningApp";
+import { debounce } from "./utils/debounce";
+
+/**
+ * Launch the LightningJS application sized to the current viewport.
+ */
+function launchLightningApp(width: number, height: number): void {
+  Blits.Launch(LightningApp, "app", {
+    w: width,
+    h: height,
+  });
+}
+
+/** Milliseconds to wait before applying the final size after a resize */
+const COOL_DOWN_MS: number = 100;
+
+/** Launch the app, replacing any existing canvas */
+function startApp(width: number, height: number): void {
+  const mount: HTMLElement = document.getElementById("app") as HTMLElement;
+  const oldCanvas: HTMLCanvasElement | null = mount.querySelector("canvas");
+
+  // Launch the new LightningJS canvas before removing the old one to minimize
+  // the time the screen goes blank during a resize
+  launchLightningApp(width, height);
+
+  if (oldCanvas !== null) {
+    oldCanvas.remove();
+  }
+}
+
+const debouncedStartApp: (...errArgs: Parameters<typeof startApp>) => void =
+  debounce(startApp, COOL_DOWN_MS);
+
+window.addEventListener("resize", (): void => {
+  debouncedStartApp(window.innerWidth, window.innerHeight);
+});
 
 /**
  * Application entry point. Loads global state and launches the LightningJS
  * view.
  */
-launchLightningApp();
+startApp(window.innerWidth, window.innerHeight);

--- a/src/launchApp.ts
+++ b/src/launchApp.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2025 Garrett Brown
+ * This file is part of meditation.surf - https://github.com/eigendude/meditation.surf
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ * See the file LICENSE.txt for more information.
+ */
+
+import Blits from "@lightningjs/blits";
+
+import LightningApp from "./LightningApp";
+import { debounce } from "./utils/debounce";
+
+/**
+ * Launch the LightningJS application sized to the current viewport.
+ */
+function launchLightningApp(width: number, height: number): void {
+  Blits.Launch(LightningApp, "app", {
+    w: width,
+    h: height,
+  });
+}
+
+/** Milliseconds to wait before applying the final size after a resize */
+const COOL_DOWN_MS: number = 100;
+
+/** Launch the app, replacing any existing canvas */
+function startApp(width: number, height: number): void {
+  const mount: HTMLElement = document.getElementById("app") as HTMLElement;
+  const oldCanvas: HTMLCanvasElement | null = mount.querySelector("canvas");
+
+  // Launch the new LightningJS canvas before removing the old one to minimize
+  // the time the screen goes blank during a resize
+  launchLightningApp(width, height);
+
+  if (oldCanvas !== null) {
+    oldCanvas.remove();
+  }
+}
+
+/** Start the app and watch for window size changes */
+export function launchApp(): void {
+  const debouncedStartApp: (...errArgs: Parameters<typeof startApp>) => void =
+    debounce(startApp, COOL_DOWN_MS);
+
+  window.addEventListener("resize", (): void => {
+    debouncedStartApp(window.innerWidth, window.innerHeight);
+  });
+
+  startApp(window.innerWidth, window.innerHeight);
+}

--- a/src/utils/debounce.ts
+++ b/src/utils/debounce.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2025 Garrett Brown
+ * This file is part of meditation.surf - https://github.com/eigendude/meditation.surf
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ * See the file LICENSE.txt for more information.
+ */
+
+/**
+ * Create a function that executes the callback immediately and again after the
+ * specified delay if it continues to be invoked. The trailing execution uses
+ * the arguments from the last invocation.
+ *
+ * @param callback - Function to debounce
+ * @param waitMs - Milliseconds to wait before the trailing execution
+ * @returns A debounced version of the callback
+ */
+export function debounce<Args extends unknown[]>(
+  callback: (...errArgs: Args) => void,
+  waitMs: number,
+): (...errArgs: Args) => void {
+  let timer: number | undefined;
+
+  return (...errArgs: Args): void => {
+    if (timer === undefined) {
+      callback(...errArgs);
+    }
+
+    window.clearTimeout(timer);
+    timer = window.setTimeout((): void => {
+      callback(...errArgs);
+      timer = undefined;
+    }, waitMs);
+  };
+}


### PR DESCRIPTION
## Summary
- tile the app icon into four quadrants
- use new QuadIcon component in the Lightning app

## Testing
- `pnpm format`
- `pnpm lint`
- `pnpm build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68449ac8222083269ca946edde3845dd