### PR TITLE
Add VideoPlayer state

### DIFF
--- a/src/app/VideoPlayerState.ts
+++ b/src/app/VideoPlayerState.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2025 Garrett Brown
+ * This file is part of meditation.surf - https://github.com/eigendude/meditation.surf
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ * See the file LICENSE.txt for more information.
+ */
+
+import { VideoPlayer } from "@lightningjs/sdk";
+
+/**
+ * Wrapper holding a reference to the Lightning SDK VideoPlayer.
+ * This module initializes the VideoPlayer once and exposes it
+ * so that app instances can access the same underlying resources
+ * even when the application is recreated.
+ */
+class VideoPlayerState {
+  /** Global VideoPlayer instance from the Lightning SDK. */
+  public readonly player: typeof VideoPlayer;
+
+  /** True after the video player has been configured and started. */
+  private initialized: boolean;
+
+  constructor() {
+    // The VideoPlayer plugin sets up its video tag only once.
+    this.player = VideoPlayer;
+    this.initialized = false as boolean;
+  }
+
+  /**
+   * Configure the shared video player and start playback if needed.
+   *
+   * @param width - Width of the viewport in pixels.
+   * @param height - Height of the viewport in pixels.
+   */
+  public initialize(width: number, height: number): void {
+    // Size the <video> element to cover the viewport
+    this.player.position(0, 0);
+    this.player.size(width, height);
+
+    if (!this.initialized) {
+      // Place the video behind the Lightning canvas
+      const videoEl: HTMLVideoElement | null =
+        (this.player as unknown as { _videoEl: HTMLVideoElement })._videoEl ??
+        null;
+      if (videoEl !== null) {
+        videoEl.style.zIndex = "0";
+      }
+
+      // Start playing Big Buck Bunny on first initialization
+      this.player.open(
+        "https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4",
+      );
+      this.player.loop(true);
+      this.initialized = true as boolean;
+    }
+  }
+}
+
+/** Singleton instance of the video player state. */
+const videoPlayerState: VideoPlayerState = new VideoPlayerState();
+
+export default videoPlayerState;

--- a/src/app/launchApp.ts
+++ b/src/app/launchApp.ts
@@ -10,6 +10,7 @@ import Blits from "@lightningjs/blits";
 
 import { debounce } from "../utils/debounce";
 import LightningApp from "./LightningApp";
+import videoPlayerState from "./VideoPlayerState";
 
 /**
  * Launch the LightningJS application sized to the current viewport.
@@ -28,6 +29,10 @@ const COOL_DOWN_MS: number = 100;
 function startApp(width: number, height: number): void {
   const mount: HTMLElement = document.getElementById("app") as HTMLElement;
   const oldCanvas: HTMLCanvasElement | null = mount.querySelector("canvas");
+
+  // Configure the shared VideoPlayer instance so the underlying <video>
+  // element is reused across app restarts.
+  videoPlayerState.initialize(width, height);
 
   // Launch the new LightningJS canvas before removing the old one to minimize
   // the time the screen goes blank during a resize


### PR DESCRIPTION
## Summary
- maintain shared Lightning VideoPlayer across app restarts
- keep video element alive when recreating the Blits app
- load Big Buck Bunny MP4 on first launch

## Testing
- `pnpm lint`
- `pnpm build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6844b2b9d798832680a670b39003c40d