### PR TITLE
Add fullscreen toggle overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -94,6 +94,36 @@
         overflow: hidden;
         background-color: #000000;
       }
+
+      /* Fullscreen toggle button in the upper right corner */
+      #fullscreen-button {
+        position: absolute;
+        top: 0.5rem;
+        right: 0.5rem;
+        width: 3rem;
+        height: 3rem;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background-color: rgba(0, 0, 0, 0.6);
+        border: none;
+        border-radius: 0.25rem;
+        cursor: pointer;
+        transition: opacity 0.5s ease;
+        opacity: 1;
+        z-index: 1000;
+      }
+
+      /* Fade the button out when idle */
+      #fullscreen-button.fade-out {
+        opacity: 0;
+      }
+
+      #fullscreen-button svg {
+        width: 1.5rem;
+        height: 1.5rem;
+        fill: #ffffff;
+      }
     </style>
   </head>
   <body>

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,8 @@
  */
 
 import { launchApp } from "./app/launchApp";
+import { setupFullscreenButton } from "./utils/fullscreen";
 
 // Application entry point
 launchApp();
+setupFullscreenButton();

--- a/src/utils/fullscreen.ts
+++ b/src/utils/fullscreen.ts
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2025 Garrett Brown
+ * This file is part of meditation.surf - https://github.com/eigendude/meditation.surf
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ * See the file LICENSE.txt for more information.
+ */
+
+/**
+ * Time in milliseconds before the fullscreen button fades out after user
+ * interaction.
+ */
+const FULLSCREEN_TIMEOUT_MS: number = 4000;
+
+/** SVG icon for entering fullscreen mode. */
+const FULLSCREEN_ICON: string =
+  '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 9V4h5V2H2v7h2zm15-7h-5v2h5v5h2V2h-2zM19 15v5h-5v2h7v-7h-2zm-10 5H4v-5H2v7h7v-2z"/></svg>';
+
+/** SVG icon for exiting fullscreen mode. */
+const EXIT_FULLSCREEN_ICON: string =
+  '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M15 4h5v5h-2V6h-3V4zM9 4v2H6v3H4V4h5zm10 10h2v5h-5v-2h3v-3zm-12 3h3v2H4v-5h2v3z"/></svg>';
+
+/**
+ * Create and attach a fullscreen toggle button to the page. The button fades
+ * out after a short delay and reappears on user interaction.
+ */
+export function setupFullscreenButton(): void {
+  const button: HTMLButtonElement = document.createElement("button");
+  button.id = "fullscreen-button";
+  button.innerHTML = FULLSCREEN_ICON;
+  button.ariaLabel = "Enter full screen";
+
+  let fadeTimer: number | undefined;
+
+  /** Show the button and start a new fade-out timer. */
+  const showButton = (): void => {
+    button.classList.remove("fade-out");
+    window.clearTimeout(fadeTimer);
+    fadeTimer = window.setTimeout((): void => {
+      button.classList.add("fade-out");
+    }, FULLSCREEN_TIMEOUT_MS);
+  };
+
+  /** Toggle fullscreen mode using the browser's fullscreen API. */
+  const toggleFullscreen = (): void => {
+    if (document.fullscreenElement !== null) {
+      document.exitFullscreen().catch((err: unknown): void => {
+        console.error("Failed to exit full screen", err);
+      });
+    } else {
+      document.documentElement
+        .requestFullscreen()
+        .catch((err: unknown): void => {
+          console.error("Failed to enter full screen", err);
+        });
+    }
+  };
+
+  button.addEventListener("click", toggleFullscreen);
+
+  document.addEventListener("fullscreenchange", (): void => {
+    if (document.fullscreenElement !== null) {
+      button.innerHTML = EXIT_FULLSCREEN_ICON;
+      button.ariaLabel = "Exit full screen";
+    } else {
+      button.innerHTML = FULLSCREEN_ICON;
+      button.ariaLabel = "Enter full screen";
+    }
+    showButton();
+  });
+
+  document.addEventListener("mousemove", showButton);
+  document.addEventListener("touchstart", showButton);
+
+  document.body.appendChild(button);
+  showButton();
+}


### PR DESCRIPTION
## Summary
- add a fullscreen toggle button that fades out after a short delay
- call the new helper from the entrypoint
- style the fullscreen button in the page

## Testing
- `pnpm lint`
- `pnpm build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_684677fa6a9083268af1d4ed7af65fae