### PR TITLE
Replace hls.js with Shaka Player

### DIFF
--- a/src/app/VideoPlayerState.ts
+++ b/src/app/VideoPlayerState.ts
@@ -9,7 +9,8 @@
 import { Ads, Lightning, Log, Settings, VideoPlayer } from "@lightningjs/sdk";
 import { initSettings } from "@lightningjs/sdk/src/Settings";
 import { initLightningSdkPlugin } from "@metrological/sdk";
-import Hls from "hls.js";
+
+/* global shaka */
 
 /**
  * Wrapper holding a reference to the Lightning SDK VideoPlayer.
@@ -21,8 +22,8 @@ class VideoPlayerState {
   /** Global VideoPlayer instance from the Lightning SDK. */
   public readonly videoPlayer: typeof VideoPlayer;
 
-  /** Active hls.js instance or `null` when not using hls.js. */
-  private hls: Hls | null;
+  /** Active Shaka Player instance or `null` when not using Shaka. */
+  private shakaPlayer: shaka.Player | null;
 
   /** URL of the demo video used for testing playback. */
   private static readonly DEMO_URL: string =
@@ -43,7 +44,7 @@ class VideoPlayerState {
   constructor() {
     // The VideoPlayer plugin sets up its video tag only once.
     this.videoPlayer = VideoPlayer;
-    this.hls = null as Hls | null;
+    this.shakaPlayer = null as shaka.Player | null;
     this.initialized = false as boolean;
     this.appInstance = null as unknown | null;
     this.opened = false as boolean;
@@ -165,33 +166,46 @@ class VideoPlayerState {
 
       // Trigger the plugin's setup routine so the `<video>` element is created.
       this.videoPlayer.hide();
-      // Always use hls.js for HLS playback rather than relying on native
-      // browser support. If hls.js is not supported, playback will not start.
+      // Always use Shaka Player for HLS playback rather than relying on native
+      // browser support. If Shaka is not supported, playback will not start.
       this.videoPlayer.loader(
         (url: string, videoEl: HTMLVideoElement): Promise<void> => {
           return new Promise((resolve: () => void): void => {
-            if (!Hls.isSupported()) {
-              console.error("hls.js is not supported in this browser");
-              resolve();
-              return;
-            }
+            void import("shaka-player/dist/shaka-player.compiled.js").then(
+              (): void => {
+                shaka.polyfill.installAll();
+                if (!shaka.Player.isBrowserSupported()) {
+                  console.error(
+                    "Shaka Player is not supported in this browser",
+                  );
+                  resolve();
+                  return;
+                }
 
-            this.hls = new Hls();
-            this.hls.on(Hls.Events.MEDIA_ATTACHED, (): void => {
-              this.hls?.loadSource(url);
-              resolve();
-            });
-            this.hls.attachMedia(videoEl);
+                this.shakaPlayer = new shaka.Player(videoEl);
+                this.shakaPlayer
+                  .load(url)
+                  .then((): void => {
+                    resolve();
+                  })
+                  .catch((error: unknown): void => {
+                    console.error("Failed to load stream with Shaka", error);
+                    resolve();
+                  });
+              },
+            );
           });
         },
       );
 
-      // Tear down hls.js instances to keep resources clean.
+      // Tear down Shaka Player instances to keep resources clean.
       this.videoPlayer.unloader((videoEl: HTMLVideoElement): Promise<void> => {
         return new Promise((resolve: () => void): void => {
-          if (this.hls !== null) {
-            this.hls.destroy();
-            this.hls = null as Hls | null;
+          if (this.shakaPlayer !== null) {
+            this.shakaPlayer.destroy().catch((err: unknown): void => {
+              console.error("Failed to destroy Shaka Player", err);
+            });
+            this.shakaPlayer = null as shaka.Player | null;
           }
           videoEl.removeAttribute("src");
           videoEl.load();

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -13,3 +13,6 @@
  */
 declare module "@lightningjs/sdk/src/Settings";
 declare module "@metrological/sdk";
+// Shaka Player does not ship TypeScript module declarations.
+// Provide a minimal module definition so it can be imported.
+declare module "shaka-player/dist/shaka-player.compiled.js";


### PR DESCRIPTION
## Summary
- swap out hls.js integration for Shaka Player
- declare module for Shaka Player types

## Testing
- `pnpm lint`
- `pnpm build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68472cad264083268dba8ed85833764d