### PR TITLE
Fix repeated video load errors

### DIFF
--- a/src/app/VideoPlayerState.ts
+++ b/src/app/VideoPlayerState.ts
@@ -230,6 +230,12 @@ export class VideoPlayerState {
    * @param url - Media URL to play.
    */
   public playUrl(url: string): void {
+    if (this.opened) {
+      // If a stream is already loaded, resume playback without reloading.
+      this.videoPlayer.play();
+      return;
+    }
+
     this.videoPlayer.mute(true);
     this.videoPlayer.open(url);
 

--- a/src/app/launchApp.ts
+++ b/src/app/launchApp.ts
@@ -33,14 +33,15 @@ function launchLightningApp(width: number, height: number): void {
 function startApp(width: number, height: number): void {
   const mount: HTMLElement = document.getElementById("app") as HTMLElement;
   const oldCanvas: HTMLCanvasElement | null = mount.querySelector("canvas");
-  const previousApp: unknown | null = videoPlayerState.getAppInstance();
+  const previousApp: unknown | null | undefined =
+    videoPlayerState.getAppInstance();
 
   // Launch the new LightningJS canvas before destroying the previous instance
   // so the screen remains visible during the transition.
   launchLightningApp(width, height);
 
   // Clean up the old Lightning application to free its WebGL context.
-  if (previousApp !== null) {
+  if (previousApp !== null && previousApp !== undefined) {
     const instance: any = previousApp as any;
     try {
       if (typeof instance.quit === "function") {


### PR DESCRIPTION
## Summary
- avoid destroying undefined Lightning app instances
- skip reloading the video if playback is already started

## Testing
- `pnpm lint`
- `pnpm build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68477e812df0832686d4f469e1390e16