### PR TITLE
Refactor resource paths

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -19,6 +19,13 @@ import {
 
 import ShakaVideo from "@/components/ShakaVideo";
 
+// Path to the application icon displayed while the video loads
+const APP_ICON_PATH: string = "@/assets/images/icon-1500x1500.png";
+
+// URL for the sample surfing video stream
+const VIDEO_HLS_STREAM: string =
+  "https://stream.mux.com/7YtWnCpXIt014uMcBK65ZjGfnScdcAneU9TjM9nGAJhk.m3u8";
+
 // Ensure the container always fills the viewport, even when browser UI
 // elements like the address bar dynamically show or hide. Use `dvh` units
 // so the value adjusts with viewport changes.
@@ -31,11 +38,11 @@ export default function HomeScreen(): JSX.Element {
   return (
     <View style={styles.container as ViewStyle}>
       <Image
-        source={require("@/assets/images/icon-1500x1500.png")}
+        source={require(APP_ICON_PATH)}
         resizeMode="contain"
         style={styles.icon as ImageStyle}
       />
-      <ShakaVideo uri="https://stream.mux.com/7YtWnCpXIt014uMcBK65ZjGfnScdcAneU9TjM9nGAJhk.m3u8" />
+      <ShakaVideo uri={VIDEO_HLS_STREAM} />
     </View>
   );
 }

--- a/components/ShakaVideo.tsx
+++ b/components/ShakaVideo.tsx
@@ -11,6 +11,9 @@ import React, { useEffect, useRef } from "react";
 import { StyleSheet, type ViewStyle } from "react-native";
 import type * as shakaNamespace from "shaka-player/shaka-player.uncompiled.js";
 
+// Constant identifying the Shaka Player module to dynamically import
+const SHAKA_PLAYER_MODULE: string = "shaka-player/shaka-player.uncompiled.js";
+
 export interface ShakaVideoProps {
   readonly uri: string;
 }
@@ -32,7 +35,7 @@ export default function ShakaVideo({
     // Dynamically load the uncompiled Shaka Player to ensure compatibility
     // with the latest React Native runtime. The compiled build targets older
     // JavaScript environments and can trigger version mismatch warnings.
-    void import("shaka-player/shaka-player.uncompiled.js")
+    void import(SHAKA_PLAYER_MODULE)
       .then((shaka: typeof shakaNamespace) => {
         // Create the Shaka Player without attaching it to a media element.
         player = new shaka.Player();


### PR DESCRIPTION
## Summary
- pull video and icon paths to constants
- centralize Shaka module path

## Testing
- `pnpm lint:prettier`
- `pnpm lint:eslint`
- `pnpm lint:expo`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_685e18247c548326bcf6fb1a09ec95f3