### PR TITLE
Fix Metro resolution for JSX runtime

### DIFF
--- a/metro.config.cjs
+++ b/metro.config.cjs
@@ -16,4 +16,8 @@ const config = getDefaultConfig(__dirname);
 // Treat `.html` files as assets so the WebView can load the bundled build.
 config.resolver.assetExts.push("html");
 
+// Enable Node's "exports" field in package.json for module resolution.
+// This is required for modules like "react/jsx-runtime" to resolve correctly.
+config.resolver.unstable_enablePackageExportsResolution = true;
+
 module.exports = config;


### PR DESCRIPTION
## Summary
- enable package exports resolution for Metro so `react/jsx-runtime` loads

## Testing
- `pnpm lint:prettier`
- `pnpm lint:eslint`
- `pnpm lint:expo`
- `pnpm build:web`
- `pnpm build:webview`


------
https://chatgpt.com/codex/tasks/task_e_6864576ddb9c83269f38881aed34641e