### PR TITLE
Fix web build by mapping React JSX runtime

### DIFF
--- a/metro.config.cjs
+++ b/metro.config.cjs
@@ -16,4 +16,15 @@ const config = getDefaultConfig(__dirname);
 // Treat `.html` files as assets so the WebView can load the bundled build.
 config.resolver.assetExts.push("html");
 
+// Metro does not fully support React's package exports yet. Explicitly map
+// the JSX runtime modules so that static rendering can locate them.
+config.resolver.extraNodeModules = {
+  // Direct paths are used because React's package exports field does not
+  // expose these files to CommonJS consumers yet.
+  "react/jsx-runtime": require.resolve("./node_modules/react/jsx-runtime.js"),
+  "react/jsx-dev-runtime": require.resolve(
+    "./node_modules/react/jsx-dev-runtime.js",
+  ),
+};
+
 module.exports = config;


### PR DESCRIPTION
## Summary
- patch metro config so Metro can locate `react/jsx-runtime`

## Testing
- `pnpm lint:prettier`
- `pnpm lint:eslint`
- `pnpm lint:expo`
- `pnpm build:web`
- `pnpm build:webview`


------
https://chatgpt.com/codex/tasks/task_e_6864576ddb9c83269f38881aed34641e