### PR TITLE
Fix Metro JSX runtime resolution

### DIFF
--- a/metro.config.cjs
+++ b/metro.config.cjs
@@ -16,4 +16,18 @@ const config = getDefaultConfig(__dirname);
 // Treat `.html` files as assets so the WebView can load the bundled build.
 config.resolver.assetExts.push("html");
 
+// Ensure that React's new JSX runtime can be resolved correctly in Metro.
+// Metro doesn't fully support the `exports` field used by React yet. Explicit
+// paths guarantee that modules like `react/jsx-runtime` resolve without errors
+// during static rendering.
+config.resolver.extraNodeModules = {
+  "react/jsx-runtime": require.resolve("react/jsx-runtime"),
+  "react/jsx-dev-runtime": require.resolve("react/jsx-dev-runtime"),
+};
+
+// Enable Node's "exports" field handling for packages that support it. This is
+// marked unstable in Metro but required for modern modules that rely on
+// subpath exports.
+config.resolver.unstable_enablePackageExportsResolution = true;
+
 module.exports = config;

--- a/metro.config.cjs
+++ b/metro.config.cjs
@@ -23,6 +23,13 @@ config.resolver.assetExts.push("html");
 config.resolver.extraNodeModules = {
   "react/jsx-runtime": require.resolve("react/jsx-runtime"),
   "react/jsx-dev-runtime": require.resolve("react/jsx-dev-runtime"),
+  // React Native Web depends on this package, but Metro occasionally
+  // fails to locate it when using pnpm's symlinked node_modules
+  // structure. Explicitly mapping the module ensures resolution
+  // succeeds during static rendering.
+  "@react-native/normalize-colors": require.resolve(
+    "@react-native/normalize-colors",
+  ),
 };
 
 // Enable Node's "exports" field handling for packages that support it. This is

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "web": "expo start --web"
   },
   "dependencies": {
+    "@react-native/normalize-colors": "0.79.4",
     "expo": "^53.0.13",
     "expo-router": "^5.1.1",
     "expo-splash-screen": "^0.30.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
 
   .:
     dependencies:
+      '@react-native/normalize-colors':
+        specifier: 0.79.4
+        version: 0.79.4
       expo:
         specifier: ^53.0.13
         version: 53.0.15(@babel/core@7.27.7)(@expo/metro-runtime@5.0.4(react-native@0.79.4(@babel/core@7.27.7)(@types/react@19.0.14)(react@19.0.0)))(react-native-webview@13.13.5(react-native@0.79.4(@babel/core@7.27.7)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.4(@babel/core@7.27.7)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
@@ -3436,7 +3439,6 @@ packages:
 
   shaka-player@4.15.5:
     resolution: {integrity: sha512-WkL5A2VeRmZS9yZCGgXuyE4yWIbv9y296OKwZL7WXB1N1lVL0sX5iu1uNQPturm6IM58OagiQ4IEOi9X0eQLaQ==}
-    engines: {node: '>=18'}
 
   shallowequal@1.1.0:
     resolution: {integrity: sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==}


### PR DESCRIPTION
## Summary
- map `react/jsx-runtime` and `react/jsx-dev-runtime` so Metro can resolve them
- enable package exports resolution for Metro

## Testing
- `pnpm lint:prettier`
- `pnpm lint:eslint`
- `pnpm lint:expo`
- `pnpm build:web`
- `pnpm build:webview`


------
https://chatgpt.com/codex/tasks/task_e_686462d6b32c83269ee1368ed5c6ced0